### PR TITLE
[IMP] Run tests on all supported Odoo versions

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM odoo:16
+ARG ODOO_VERSION
+FROM odoo:$ODOO_VERSION
 
 ARG PROJECT_ROOT_PATH=.
 ARG PROJECT_PKG_PATH=/home/odoo/osut
@@ -9,11 +10,12 @@ USER root
 
 RUN apt update;  \
     curl -o  ${CHROME_DEB_PATH} https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb; \
-    apt install -y ${CHROME_DEB_PATH}
+    apt install -y ${CHROME_DEB_PATH}; \
+    python3 -m pip install --upgrade pip
 
 COPY --chown=odoo:odoo ${PROJECT_ROOT_PATH} ${PROJECT_PKG_PATH}
 COPY --chown=odoo:odoo ${PROJECT_ROOT_PATH}/tests_odoo ${PROJECT_ADDONS_PATH}
 
-RUN pip install ${PROJECT_PKG_PATH}
+RUN python3 -m pip install ${PROJECT_PKG_PATH}
 
 USER odoo

--- a/.docker/chrome-compose.yaml
+++ b/.docker/chrome-compose.yaml
@@ -1,9 +1,12 @@
-name: chrome-osut
+name: chrome-odoosel
 services:
   odoo:
+    image: vauxoo/odoo-selenium:${ODOO_VERSION-16}
     build:
       context: ..
       dockerfile: .docker/Dockerfile
+      args:
+        ODOO_VERSION: ${ODOO_VERSION-16}
     depends_on:
       - db
     command: ["odoo", "-d", "selenium", "-i", "test_selenium", "--test-tags", "/test_selenium", "--workers=0", "--stop-after-init"]

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -23,11 +23,15 @@ jobs:
         run: pre-commit run --all-files
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        odoo: [14, 15, 16]
     steps:
       - uses: actions/checkout@v3
       - name: Build container
-        run: docker compose -f .docker/chrome-compose.yaml build
-      - name: Pull images
-        run: docker compose -f .docker/chrome-compose.yaml pull
+        run: ODOO_VERSION=${{ matrix.odoo }} docker compose -f .docker/chrome-compose.yaml build
+      - name: Pull supporting containers
+        run: docker compose -f .docker/chrome-compose.yaml pull db
       - name: Run embedded Selenium tests
-        run: docker compose -f .docker/chrome-compose.yaml up --abort-on-container-exit
+        run: ODOO_VERSION=${{ matrix.odoo }} docker compose -f .docker/chrome-compose.yaml up --abort-on-container-exit --force-recreate

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ class TestSelenium(SeleniumMixin, HttpCase):
         self.stop_selenium()
 
     def test_login_page(self):
-        self.driver.get(f"{self.base_url()}/web/login")
+        self.driver.get(f"{self.base_url()}/web/login")  # base_url() does not exist in 14.0
         email_input = self.driver.find_element(By.ID, "login")
 
         self.assertEqual("Email", email_input.get_attribute("placeholder"))
@@ -69,7 +69,26 @@ is installed as users would, meaning this environment is as close to possible as
 To run the test suite you can simply issue the following command:
 
 ```shell
-docker compose -f .docker/chrome-compose.yaml up --build --abort-on-container-exit
+docker compose -f .docker/chrome-compose.yaml up --build --abort-on-container-exit --force-recreate
 ```
 
-Make sure the working directory when running said command is the repository's root.
+Make sure the working directory when running said command is the repository's root. Docker automatically checks for
+changed files so nothing needs to be performed on your part (other than running the command above), this makes testing
+iterative changes really easy and quick.
+
+By default, the test suite runs against the newest Odoo version. To run the test suite with a different Odoo version it
+is as easy as specifying it:
+
+```shell
+ODOO_VERSION=15 docker compose -f .docker/chrome-compose.yaml up --build --abort-on-container-exit --force-recreate
+```
+
+The command above will run tests against Odoo 15.0. Images are tagged as: `vauxoo/odoo-selenium:${ODOO_VERSION}` so
+if you wanted to inspect the image built above, you can simply use:
+
+```shell
+docker run -it --rm --entrypoint=/bin/bash vauxoo/odoo-selenium:15
+```
+
+**Note: If your tests fail, and you see old code being referenced, you are using an old image! That's why
+`--force-recreate` is used.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osut"
-requires-python = ">=3.8.0"
+requires-python = ">=3.7.0"
 dynamic = ["version", "description"]
 dependencies = [
     "selenium >= 4.11"

--- a/tests_odoo/test_selenium/tests/test_selenium.py
+++ b/tests_odoo/test_selenium/tests/test_selenium.py
@@ -1,5 +1,6 @@
 from selenium.webdriver.common.by import By
 
+from odoo.tools import config
 from odoo.tests import HttpCase, tagged
 
 from osut.selenium import SeleniumMixin
@@ -7,6 +8,12 @@ from osut.selenium import SeleniumMixin
 
 @tagged("-at_install", "post_install")
 class TestSelenium(SeleniumMixin, HttpCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.odoo_url = "http://%s:%s" % ("127.0.0.1", config['http_port'])  # base_url does not exist in 14.0
+
     def setUp(self):
         super().setUp()
         self.start_selenium()
@@ -16,7 +23,7 @@ class TestSelenium(SeleniumMixin, HttpCase):
         self.stop_selenium()
 
     def test_login_page(self):
-        self.driver.get(f"{self.base_url()}/web/login")
+        self.driver.get(f"{self.odoo_url}/web/login")
         email_input = self.driver.find_element(By.ID, "login")
 
         self.assertEqual("Email", email_input.get_attribute("placeholder"))


### PR DESCRIPTION
Related to #1.

This commit adds Odoo versions 14 and 15 to be run during the test pipeline. It also imports annotations from __future__ in order to use type hinting with older Python versions found in Odoo setups.

Instructions on running the test suite with different odoo versions have also been added to the README.