### PR TITLE
Added new file for common expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ class TestSelenium(SeleniumMixin, HttpCase):
         self.stop_selenium()
 
     def test_login_page(self):
-        self.driver.get(f"{self.base_url()}/web/login")  # base_url() does not exist in 14.0
+        self.navigate(f"{self.base_url()}/web/login")  # base_url() does not exist in 14.0
         email_input = self.driver.find_element(By.ID, "login")
 
         self.assertEqual("Email", email_input.get_attribute("placeholder"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,12 @@ dependencies = [
 [project.urls]
 Source = "https://github.com/vauxoo/odoo-selenium"
 
+[tool.black]
+line-length=119
+
+[tool.pylint]
+max-line-length=119
+
 [build-system]
 requires = ["flit_core >=3.9,<4"]
 build-backend = "flit_core.buildapi"

--- a/src/odoo_selenium/expectations.py
+++ b/src/odoo_selenium/expectations.py
@@ -1,0 +1,20 @@
+"""Collection of useful expectations to be used with Selenium waits"""
+from selenium.common import JavascriptException
+from selenium.webdriver.remote.webdriver import WebDriver
+
+
+def owl_has_loaded(driver: WebDriver) -> bool:
+    """An expectation for Odoo's OWL framework to have finished loading.
+
+    :param WebDriver driver: Driver that has navigated to an Odoo website and expects OWL to have loaded.
+    :return: True if OWL has loaded, False otherwise.
+    """
+    try:
+        return driver.execute_script("return typeof owl.config.mode !== 'undefined'")
+    except JavascriptException:
+        try:
+            return driver.execute_script(
+                "return Array.from(__OWL_DEVTOOLS__.apps).some((app) => app.root?.status === 1)"
+            )
+        except JavascriptException:
+            return False

--- a/src/odoo_selenium/selenium.py
+++ b/src/odoo_selenium/selenium.py
@@ -11,6 +11,8 @@ from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.support.wait import WebDriverWait
 
+from odoo_selenium.expectations import owl_has_loaded
+
 _logger = logging.getLogger(__name__)
 
 
@@ -58,9 +60,7 @@ class SeleniumMixin:
             try:
                 self.env["base"].flush()
             except (AttributeError, KeyError):
-                _logger.warning(
-                    "Failed to flush, changes may not be reflected on the website"
-                )
+                _logger.warning("Failed to flush, changes may not be reflected on the website")
 
         if flags is not None:
             self._chrome_flags.update(flags)
@@ -90,8 +90,15 @@ class SeleniumMixin:
         try:
             self._wait_remaining_requests()
         except AttributeError:
-            _logger.warning(
-                "Failed to call _wait_remaining_requests, is this an HttpCase?"
-            )
+            _logger.warning("Failed to call _wait_remaining_requests, is this an HttpCase?")
 
         self.driver.quit()
+
+    def navigate(self, url: str):
+        """Navigates to the specified Odoo website and waits for the website components to load.
+
+        :param str url: URL to navigate to. It MUST be an Odoo website, otherwise it is likely to wait indefinitely
+        for Odoo specific components (that are not there) to load.
+        """
+        self.driver.get(url)
+        self.wait.until(owl_has_loaded)

--- a/tests_odoo/test_selenium/tests/test_selenium.py
+++ b/tests_odoo/test_selenium/tests/test_selenium.py
@@ -23,7 +23,7 @@ class TestSelenium(SeleniumMixin, HttpCase):
         self.stop_selenium()
 
     def test_login_page(self):
-        self.driver.get(f"{self.odoo_url}/web/login")
+        self.navigate(f"{self.odoo_url}/web/login")
         email_input = self.driver.find_element(By.ID, "login")
 
         self.assertEqual("Email", email_input.get_attribute("placeholder"))


### PR DESCRIPTION
Most test cases will need to use explicit waits to assert certain
conditions have happened before proceeding. A new file which implements
common conditions needed throughout tests has been added.

A new method `navigate` which uses one of these expectations has also
been added. This ensures Odoo's frontend has loaded completely before
proceeding, preventing stuff like clicks not being registered from
happening.