### PR TITLE
Refactor tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,8 @@
 [tox]
+min_version = 4.8
 envlist =
-    build,
-
-[testenv]
-parallel_show_output=true
-setenv =
-    PYTHONPATH={toxinidir}/tests
-    PYTHONUNBUFFERED=yes
-passenv =
-    *
-usedevelop = true
+    build
+    lint
 
 [testenv:build]
 deps =
@@ -25,11 +18,7 @@ commands =
     python -c '''import sys,pip,os,glob;os.chdir("dist");sys.argv = ["", "install", "-U", "--force-reinstall", glob.glob("*.tar.gz")[-1], "--use-feature=no-binary-enable-wheel-cache"];pip.main()'''
 
 [testenv:lint]
-deps =
-    pre-commit-vauxoo
-allowlist_externals =
-    git
-commands =
-    pre-commit-vauxoo -t all
-    # pre-commit-vauxoo update pyproject.toml file so reverting it
-    git checkout HEAD -- pyproject.toml
+deps = pre-commit-vauxoo
+allowlist_externals = git
+commands = pre-commit-vauxoo -t all
+commands_post = git checkout HEAD -- pyproject.toml


### PR DESCRIPTION
* Removed unecessary section on tox.ini
* Cleaned up lint environment, added command_post to ensure pyproject.toml is always reverted as it was not doing so whenever pre-commit-vauxoo failed.