### PR TITLE
Fix selenium crash

### DIFF
--- a/.docker/entrypoint.sh
+++ b/.docker/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 coverage run /usr/bin/odoo -i test_selenium --test-tags /test_selenium --workers=0 --stop-after-init
+TEST_EXIT_CODE=$?
+
 coverage report --show-missing
 coverage html
 coverage xml
+
+exit "$TEST_EXIT_CODE"

--- a/src/odoo_selenium/selenium.py
+++ b/src/odoo_selenium/selenium.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import unittest
 from os import environ
-from resource import RLIMIT_AS, setrlimit
+from resource import RLIM_INFINITY, RLIMIT_AS, setrlimit
 from urllib.parse import urljoin
 
 from selenium.webdriver import Chrome, ChromeOptions, Remote
@@ -85,7 +85,7 @@ class SeleniumCase(HttpCase):
         if grid_url:
             self.driver = Remote(command_executor=grid_url, options=ChromeOptions())
         else:
-            setrlimit(RLIMIT_AS, (16**9, 16**9))
+            setrlimit(RLIMIT_AS, (RLIM_INFINITY, RLIM_INFINITY))
 
             options = Options()
             for key, value in self.chrome_flags.items():


### PR DESCRIPTION
I was trying to run selenium tests on an Odoo 16 local development instance and selenium would always crash with the following message: 
```
selenium.common.exceptions.WebDriverException: Message: tab crashed
```

After investigating I was able to track it down to the resource limits that were being used. After setting them to infinity as Odoo does, selenium tests work fine again. Setting them to infinity may look scary but I think that is actually the default value for processes, at least on my machine, also tests are not being run in production to resource limits would not change there.